### PR TITLE
Add channel profile selector and FLoRa defaults

### DIFF
--- a/tests/test_degraded_channel_interval.py
+++ b/tests/test_degraded_channel_interval.py
@@ -50,8 +50,33 @@ def test_channels_identical_after_degrade():
         "shadowing_std",
         "detection_threshold_dBm",
         "capture_threshold_dB",
+        "flora_capture",
+        "flora_loss_model",
     ]
     reference = sim.multichannel.channels[0]
+    ple, shad, *_ = Channel.ENV_PRESETS["flora"]
+    assert reference.path_loss_exp == ple
+    assert reference.shadowing_std == shad
+    assert reference.flora_capture is True
+    assert reference.flora_loss_model == "lognorm"
     for ch in sim.multichannel.channels[1:]:
         for attr in attrs:
             assert getattr(ch, attr) == getattr(reference, attr)
+
+
+def test_custom_profile_changes_params():
+    sim = Simulator(
+        num_nodes=1,
+        num_gateways=1,
+        transmission_mode="Random",
+        packet_interval=1.0,
+        packets_to_send=1,
+        pure_poisson_mode=True,
+        mobility=False,
+        seed=1,
+    )
+    apply_adr(sim, degrade_channel=True, profile="urban")
+    ple, shad, *_ = Channel.ENV_PRESETS["urban"]
+    ch = sim.multichannel.channels[0]
+    assert ch.path_loss_exp == ple
+    assert ch.shadowing_std == shad


### PR DESCRIPTION
## Summary
- Replace static channel degradation dict with profile-based selector using `Channel.ENV_PRESETS`
- Enable FLoRa equations via `flora_capture` and `flora_loss_model`
- Allow callers to choose channel profile when applying ADR variant

## Testing
- `pytest tests/test_degraded_channel_interval.py tests/test_adr.py tests/test_flora_rssi.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6897b99722088331963206db6dd58bce