### PR TITLE
feat: allow runtime tuning of channel degradation

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,2 +1,9 @@
 [simulation]
 mu_send = 10.0
+
+[channel]
+# Paramètres optionnels pour dégrader le canal radio
+variable_noise_std = 2.0
+fine_fading_std = 2.0
+fading = rician
+rician_k = 1.0


### PR DESCRIPTION
## Summary
- reduce noise and fine fading defaults in ADR1 degradation model
- add `rician_k` fading control and read channel params from config.ini

## Testing
- `pytest` *(fails: AttributeError: 'NoneType' object has no attribute 'title')*

------
https://chatgpt.com/codex/tasks/task_e_6897b99b32d48331913548d9e8a2e25c