### PR TITLE
feat: expose channel fading parameters

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,2 +1,8 @@
 [simulation]
 mu_send = 10.0
+
+[channel]
+variable_noise_std = 2.0
+fine_fading_std = 2.0
+rician_k = 1.0
+fading = rician


### PR DESCRIPTION
## Summary
- Allow configuring channel fading and noise parameters from `config.ini`
- Reduce default noise/fading variation to ~2 dB and expose `rician_k`
- Load optional fading settings when degrading channels

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897d53bd0e083318557494dc5314151