### PR TITLE
Add capture mode option to ADR standard channel setup

### DIFF
--- a/examples/run_flora_example.py
+++ b/examples/run_flora_example.py
@@ -18,6 +18,6 @@ if __name__ == "__main__":
         seed=1,
         adr_method="avg",
     )
-    adr1(sim)
+    adr1(sim, capture_mode="flora")
     sim.run(1000)
     print(sim.get_metrics())

--- a/tests/test_degraded_channel_interval.py
+++ b/tests/test_degraded_channel_interval.py
@@ -17,7 +17,7 @@ def test_interval_with_degraded_channel():
         mobility=False,
         seed=1,
     )
-    apply_adr(sim, degrade_channel=True)
+    apply_adr(sim, degrade_channel=True, capture_mode="flora")
     sim.run()
     node = sim.nodes[0]
     average = node._last_arrival_time / node.packets_sent
@@ -43,7 +43,7 @@ def test_channels_identical_after_degrade():
         channels=multi,
         seed=1,
     )
-    apply_adr(sim, degrade_channel=True)
+    apply_adr(sim, degrade_channel=True, capture_mode="flora")
 
     attrs = [
         "path_loss_exp",

--- a/tests/test_flora_sca.py
+++ b/tests/test_flora_sca.py
@@ -21,7 +21,7 @@ CONFIG = "flora-master/simulations/examples/n100-gw1.ini"
 def test_flora_sca_compare():
     sca = Path(__file__).parent / "data" / "n100_gw1_expected.sca"
     sim = Simulator(flora_mode=True, config_file=CONFIG, seed=1, adr_method="avg")
-    adr1(sim)
+    adr1(sim, capture_mode="flora")
     sim.run(1000)
     metrics = sim.get_metrics()
 
@@ -34,12 +34,12 @@ def test_flora_sca_compare():
 @pytest.mark.slow
 def test_flora_sca_quantization_trace():
     sim = Simulator(flora_mode=True, config_file=CONFIG, seed=1, adr_method="avg")
-    adr1(sim)
+    adr1(sim, capture_mode="flora")
     sim.run(1000)
     sim_q = Simulator(
         flora_mode=True, config_file=CONFIG, seed=1, adr_method="avg", tick_ns=1
     )
-    adr1(sim_q)
+    adr1(sim_q, capture_mode="flora")
     sim_q.run(1000)
 
     def to_ns(log):


### PR DESCRIPTION
## Summary
- allow selecting `advanced` or `flora` capture modes in `adr_standard_1`
- propagate `capture_mode` to FLoRa example and relevant tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897d5b912c88331a930dd67484d47f9