### PR TITLE
Fix interval validation message

### DIFF
--- a/simulateur_lora_sfrd/run.py
+++ b/simulateur_lora_sfrd/run.py
@@ -64,7 +64,7 @@ def simulate(
         and not isinstance(interval, numbers.Integral)
         and interval > 0
     ):
-        raise ValueError("mean_interval must be positive float")
+        raise ValueError("interval must be a positive float")
     if first_interval is not None and not (
         isinstance(first_interval, numbers.Real)
         and not isinstance(first_interval, numbers.Integral)


### PR DESCRIPTION
## Summary
- clarify error message for invalid interval parameter in run simulator

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897e3b877648331989248268b9b1c70