### PR TITLE
Apply FLoRa detection threshold to non-degraded channels

### DIFF
--- a/simulateur_lora_sfrd/launcher/adr_standard_1.py
+++ b/simulateur_lora_sfrd/launcher/adr_standard_1.py
@@ -123,6 +123,12 @@ def apply(
         node.adr_ack_limit = 64
         node.adr_ack_delay = 32
 
+    if not degrade_channel:
+        for ch in sim.multichannel.channels:
+            ch.detection_threshold_dBm = Channel.flora_detection_threshold(
+                node.sf, ch.bandwidth
+            )
+
     if degrade_channel:
         new_channels = []
         base_params = _degrade_params(profile, capture_mode)

--- a/tests/test_detection_threshold.py
+++ b/tests/test_detection_threshold.py
@@ -9,3 +9,11 @@ def test_apply_sets_flora_detection_threshold():
     node = sim.nodes[0]
     expected = Channel.FLORA_SENSITIVITY[node.sf][int(node.channel.bandwidth)]
     assert node.channel.detection_threshold_dBm == expected
+
+
+def test_apply_sets_threshold_without_degradation():
+    sim = Simulator(num_nodes=1, packets_to_send=0)
+    adr_standard_1.apply(sim, degrade_channel=False)
+    node = sim.nodes[0]
+    expected = Channel.FLORA_SENSITIVITY[node.sf][int(node.channel.bandwidth)]
+    assert node.channel.detection_threshold_dBm == expected


### PR DESCRIPTION
## Summary
- Ensure FLoRa-style detection thresholds are assigned to each channel when channels are not degraded
- Add regression test covering threshold setup without channel degradation

## Testing
- `pytest tests/test_detection_threshold.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6897f53e0e648331bd9a834057f68558