### PR TITLE
Fix channel threshold initialization without residual node

### DIFF
--- a/simulateur_lora_sfrd/launcher/adr_standard_1.py
+++ b/simulateur_lora_sfrd/launcher/adr_standard_1.py
@@ -124,9 +124,10 @@ def apply(
         node.adr_ack_delay = 32
 
     if not degrade_channel:
+        sf = 12  # Default spreading factor used at start
         for ch in sim.multichannel.channels:
             ch.detection_threshold_dBm = Channel.flora_detection_threshold(
-                node.sf, ch.bandwidth
+                sf, ch.bandwidth
             )
 
     if degrade_channel:


### PR DESCRIPTION
## Summary
- Avoid using residual `node` when initializing channel detection thresholds

## Testing
- `pytest` *(fails: tests/test_degraded_channel_interval.py::test_degraded_channel_reduces_pdr)*

------
https://chatgpt.com/codex/tasks/task_e_68984466b72c833193eba4cd3a0e0429