### PR TITLE
Handle non-orthogonal SF capture thresholds from FLoRa

### DIFF
--- a/simulateur_lora_sfrd/launcher/adr_standard_1.py
+++ b/simulateur_lora_sfrd/launcher/adr_standard_1.py
@@ -8,6 +8,7 @@ from . import server
 from .advanced_channel import AdvancedChannel
 from .lorawan import TX_POWER_INDEX_TO_DBM
 from .channel import Channel
+from .gateway import FLORA_NON_ORTH_DELTA
 
 # ---------------------------------------------------------------------------
 # Channel degradation profiles.
@@ -135,9 +136,11 @@ def apply(
             )
             # Allow different SFs to interfere like in FLoRa
             ch.orthogonal_sf = False
+            ch.non_orth_delta = FLORA_NON_ORTH_DELTA
         # Propagate the non-orthogonal behaviour to existing node channels
         for node in sim.nodes:
             node.channel.orthogonal_sf = False
+            node.channel.non_orth_delta = FLORA_NON_ORTH_DELTA
         # For fixed spreading factor scenarios keep a very permissive
         # detection threshold to mirror the original behaviour
         if getattr(sim, "fixed_sf", None) is not None:
@@ -161,6 +164,7 @@ def apply(
             # Créer un canal avancé avec les paramètres mis à jour
             adv = AdvancedChannel(**params)
             adv.orthogonal_sf = False
+            adv.non_orth_delta = FLORA_NON_ORTH_DELTA
             new_channels.append(adv)
 
         # Remplacer la liste des canaux par les nouveaux canaux dégradés
@@ -174,8 +178,10 @@ def apply(
                 getattr(node, "sf", 12), node.channel.bandwidth
             )
             node.channel.orthogonal_sf = False
+            node.channel.non_orth_delta = FLORA_NON_ORTH_DELTA
 
     # Ensure server and first channel reflect the non-orthogonal setting
     sim.channel = sim.multichannel.channels[0]
     sim.channel.orthogonal_sf = False
+    sim.channel.non_orth_delta = FLORA_NON_ORTH_DELTA
     sim.network_server.channel = sim.channel

--- a/simulateur_lora_sfrd/launcher/simulator.py
+++ b/simulateur_lora_sfrd/launcher/simulator.py
@@ -855,6 +855,7 @@ class Simulator:
                     ),
                     orthogonal_sf=node.channel.orthogonal_sf,
                     capture_window_symbols=node.channel.capture_window_symbols,
+                    non_orth_delta=getattr(node.channel, "non_orth_delta", None),
                 )
 
             # Retenir le meilleur RSSI/SNR mesuré pour cette transmission

--- a/tests/test_gateway_capture.py
+++ b/tests/test_gateway_capture.py
@@ -1,4 +1,4 @@
-from simulateur_lora_sfrd.launcher.gateway import Gateway
+from simulateur_lora_sfrd.launcher.gateway import Gateway, FLORA_NON_ORTH_DELTA
 from simulateur_lora_sfrd.launcher.server import NetworkServer
 
 
@@ -69,8 +69,16 @@ def test_cross_sf_collision():
     server.gateways = [gw]
 
     # Two packets on the same frequency with different SF collide
-    gw.start_reception(1, 1, 7, -60, 1.0, 6.0, 0.0, 868e6, orthogonal_sf=False)
-    gw.start_reception(2, 2, 9, -60, 1.0, 6.0, 0.0, 868e6, orthogonal_sf=False)
+    gw.start_reception(
+        1, 1, 7, -60, 1.0, 6.0, 0.0, 868e6,
+        orthogonal_sf=False,
+        non_orth_delta=FLORA_NON_ORTH_DELTA,
+    )
+    gw.start_reception(
+        2, 2, 9, -60, 1.0, 6.0, 0.0, 868e6,
+        orthogonal_sf=False,
+        non_orth_delta=FLORA_NON_ORTH_DELTA,
+    )
     gw.end_reception(1, server, 1)
     gw.end_reception(2, server, 2)
 
@@ -83,9 +91,17 @@ def test_cross_sf_capture_after_delay():
     server.gateways = [gw]
 
     # Strong signal starts first and should capture the weaker one
-    gw.start_reception(1, 1, 7, -50, 1.0, 6.0, 0.0, 868e6, orthogonal_sf=False)
+    gw.start_reception(
+        1, 1, 7, -50, 1.0, 6.0, 0.0, 868e6,
+        orthogonal_sf=False,
+        non_orth_delta=FLORA_NON_ORTH_DELTA,
+    )
     # Weaker packet with higher SF starts after more than 5 of its symbols
-    gw.start_reception(2, 2, 9, -60, 1.0, 6.0, 0.03, 868e6, orthogonal_sf=False)
+    gw.start_reception(
+        2, 2, 9, -60, 1.0, 6.0, 0.03, 868e6,
+        orthogonal_sf=False,
+        non_orth_delta=FLORA_NON_ORTH_DELTA,
+    )
     gw.end_reception(1, server, 1)
     gw.end_reception(2, server, 2)
 


### PR DESCRIPTION
### Summary
- expose FLoRa non-orthogonal delta matrix and add `non_orth_delta` parameter to gateway
- when SFs are not orthogonal, select capture thresholds from this matrix
- propagate matrix through `adr_standard_1.apply` and simulator configuration
- adjust tests to cover cross-SF capture with the matrix

### Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898a790981c8331b57651005d4d9121