### PR TITLE
Increase channel variability in simulation config

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -2,7 +2,7 @@
 mu_send = 10.0
 
 [channel]
-variable_noise_std = 5.0
-fine_fading_std = 5.0
+variable_noise_std = 10.0
+fine_fading_std = 10.0
 rician_k = 0.0
 fading = rayleigh


### PR DESCRIPTION
## Summary
- Raise variable_noise_std and fine_fading_std to amplify channel noise and fading variability.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898c91b0574833193f808e3dd11b0e6