### PR TITLE
Adjust detection thresholds for ADR standard profile

### DIFF
--- a/simulateur_lora_sfrd/launcher/adr_standard_1.py
+++ b/simulateur_lora_sfrd/launcher/adr_standard_1.py
@@ -134,6 +134,7 @@ def apply(
             ch.detection_threshold_dBm = Channel.flora_detection_threshold(
                 sf, ch.bandwidth
             ) + ch.sensitivity_margin_dB
+            ch.detection_threshold_dBm += 20
             # Allow different SFs to interfere like in FLoRa
             ch.orthogonal_sf = False
             ch.non_orth_delta = FLORA_NON_ORTH_DELTA
@@ -164,6 +165,7 @@ def apply(
             params["detection_threshold_dBm"] = Channel.flora_detection_threshold(
                 sf, bw
             ) + params["sensitivity_margin_dB"]
+            params["detection_threshold_dBm"] += 20
             # Créer un canal avancé avec les paramètres mis à jour
             adv = AdvancedChannel(**params)
             adv.orthogonal_sf = False
@@ -180,6 +182,7 @@ def apply(
             node.channel.detection_threshold_dBm = Channel.flora_detection_threshold(
                 getattr(node, "sf", 12), node.channel.bandwidth
             ) + node.channel.sensitivity_margin_dB
+            node.channel.detection_threshold_dBm += 20
             node.channel.orthogonal_sf = False
             node.channel.non_orth_delta = FLORA_NON_ORTH_DELTA
 


### PR DESCRIPTION
## Summary
- boost channel detection thresholds by 20 dB in `adr_standard_1` for both degraded and normal channel configurations
- ensure nodes inherit the increased detection threshold

## Testing
- `PYTHONPATH=. pytest simulateur_lora_sfrd/launcher/tests/test_adr.py simulateur_lora_sfrd/launcher/tests/test_adr_ack_req.py simulateur_lora_sfrd/launcher/tests/test_sensitivity.py -q`
- `PYTHONPATH=. pytest simulateur_lora_sfrd/launcher/tests/test_adr.py simulateur_lora_sfrd/launcher/tests/test_adr_ack_req.py simulateur_lora_sfrd/launcher/tests/test_obstacle_loss.py simulateur_lora_sfrd/launcher/tests/test_sensitivity.py -q` *(fails: rssi difference not applied)*
- `PYTHONPATH=. pytest simulateur_lora_sfrd/launcher/tests -q` *(fails: panel dependency triggers numpy error)*

------
https://chatgpt.com/codex/tasks/task_e_689de748618c8331aadb5fa17c9f2cbd