### PR TITLE
Fix capture threshold for ADR standard profile

### DIFF
--- a/simulateur_lora_sfrd/launcher/adr_standard_1.py
+++ b/simulateur_lora_sfrd/launcher/adr_standard_1.py
@@ -70,7 +70,7 @@ def _degrade_params(profile: str, capture_mode: str) -> dict:
         "flora_capture": flora_capture,
         "flora_loss_model": "lognorm",
         "detection_threshold_dBm": -130.0,
-        "capture_threshold_dB": 12.0,
+        "capture_threshold_dB": 6.0,
     }
 
 def apply(


### PR DESCRIPTION
## Summary
- set `capture_threshold_dB` to 6 dB in `adr_standard_1` to match standard settings

## Testing
- `pytest` *(fails: 2 failed, 74 passed, 8 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_689deaf895648331ada414ac415770ba