### PR TITLE
Auto-load FLoRa noise table for sensitivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 Bienvenue ! Ce projet est un **simulateur complet de réseau LoRa**, inspiré du fonctionnement de FLoRa sous OMNeT++, codé entièrement en Python.
 Pour un aperçu des différences avec FLoRa, consultez docs/lorawan_features.md.
 Les principales équations sont décrites dans docs/equations_flora.md.
+
+Par défaut, le module `Channel` charge la table de bruit de FLoRa en analysant
+`flora-master/src/LoRaPhy/LoRaAnalogModel.cc` si le fichier est présent. Cette
+table est injectée dans la fonction `_flora_noise_dBm` pour les calculs de
+sensibilité. Un chemin personnalisé peut être fourni via `flora_noise_path`.
 ## 🛠️ Installation
 
 1. **Clonez ou téléchargez** le projet.

--- a/simulateur_lora_sfrd/launcher/adr_standard_1.py
+++ b/simulateur_lora_sfrd/launcher/adr_standard_1.py
@@ -130,7 +130,6 @@ def apply(
             ch.detection_threshold_dBm = Channel.flora_detection_threshold(
                 sf, ch.bandwidth
             ) + ch.sensitivity_margin_dB
-            ch.detection_threshold_dBm += 20
             # Allow different SFs to interfere like in FLoRa
             ch.orthogonal_sf = False
             ch.non_orth_delta = FLORA_NON_ORTH_DELTA
@@ -161,7 +160,6 @@ def apply(
             params["detection_threshold_dBm"] = Channel.flora_detection_threshold(
                 sf, bw
             ) + params["sensitivity_margin_dB"]
-            params["detection_threshold_dBm"] += 20
             # Créer un canal avancé avec les paramètres mis à jour
             adv = AdvancedChannel(**params)
             adv.orthogonal_sf = False
@@ -178,7 +176,6 @@ def apply(
             node.channel.detection_threshold_dBm = Channel.flora_detection_threshold(
                 getattr(node, "sf", 12), node.channel.bandwidth
             ) + node.channel.sensitivity_margin_dB
-            node.channel.detection_threshold_dBm += 20
             node.channel.orthogonal_sf = False
             node.channel.non_orth_delta = FLORA_NON_ORTH_DELTA
 

--- a/simulateur_lora_sfrd/launcher/channel.py
+++ b/simulateur_lora_sfrd/launcher/channel.py
@@ -353,7 +353,18 @@ class Channel:
         if flora_noise_path:
             self.flora_noise_table = self.parse_flora_noise_table(flora_noise_path)
         else:
-            self.flora_noise_table = self.FLORA_SENSITIVITY
+            # Automatically look for FLoRa's noise definition file
+            flora_cc = (
+                Path(__file__).resolve().parents[2]
+                / "flora-master"
+                / "src"
+                / "LoRaPhy"
+                / "LoRaAnalogModel.cc"
+            )
+            if flora_cc.is_file():
+                self.flora_noise_table = self.parse_flora_noise_table(flora_cc)
+            else:
+                self.flora_noise_table = self.FLORA_SENSITIVITY
         if obstacle_loss is not None:
             self.obstacle_loss = obstacle_loss
         elif obstacle_map is not None:


### PR DESCRIPTION
## Summary
- auto-detect LoRaAnalogModel.cc and parse its noise table when no flora_noise_path is supplied
- document automatic FLoRa noise table loading
- keep ADR1 detection threshold aligned with FLoRa values

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689dee1c41288331aac1e537594e5826