### PR TITLE
Model startup and preamble energy overheads

### DIFF
--- a/simulateur_lora_sfrd/launcher/adr_standard_1.py
+++ b/simulateur_lora_sfrd/launcher/adr_standard_1.py
@@ -130,7 +130,6 @@ def apply(
             ch.detection_threshold_dBm = Channel.flora_detection_threshold(
                 sf, ch.bandwidth
             ) + ch.sensitivity_margin_dB
-            ch.detection_threshold_dBm += 20
             # Allow different SFs to interfere like in FLoRa
             ch.orthogonal_sf = False
             ch.non_orth_delta = FLORA_NON_ORTH_DELTA
@@ -161,7 +160,6 @@ def apply(
             params["detection_threshold_dBm"] = Channel.flora_detection_threshold(
                 sf, bw
             ) + params["sensitivity_margin_dB"]
-            params["detection_threshold_dBm"] += 20
             # Créer un canal avancé avec les paramètres mis à jour
             adv = AdvancedChannel(**params)
             adv.orthogonal_sf = False
@@ -178,7 +176,6 @@ def apply(
             node.channel.detection_threshold_dBm = Channel.flora_detection_threshold(
                 getattr(node, "sf", 12), node.channel.bandwidth
             ) + node.channel.sensitivity_margin_dB
-            node.channel.detection_threshold_dBm += 20
             node.channel.orthogonal_sf = False
             node.channel.non_orth_delta = FLORA_NON_ORTH_DELTA
 

--- a/simulateur_lora_sfrd/launcher/energy_profiles.py
+++ b/simulateur_lora_sfrd/launcher/energy_profiles.py
@@ -38,7 +38,15 @@ class EnergyProfile:
 
 
 # Default profile based on the FLoRa model (OMNeT++)
-FLORA_PROFILE = EnergyProfile(tx_current_map_a=DEFAULT_TX_CURRENT_MAP_A)
+FLORA_PROFILE = EnergyProfile(
+    tx_current_map_a=DEFAULT_TX_CURRENT_MAP_A,
+    startup_current_a=1.6e-3,
+    startup_time_s=1e-3,
+    preamble_current_a=5e-3,
+    preamble_time_s=1e-3,
+    ramp_up_s=1e-3,
+    ramp_down_s=1e-3,
+)
 
 # Example of a lower power transceiver profile
 LOW_POWER_TX_MAP_A: dict[float, float] = {

--- a/simulateur_lora_sfrd/launcher/simulator.py
+++ b/simulateur_lora_sfrd/launcher/simulator.py
@@ -765,16 +765,11 @@ class Simulator:
             # Énergie consommée par la transmission (E = I * V * t)
             current_a = node.profile.get_tx_current(tx_power)
             energy_J = current_a * node.profile.voltage_v * duration
-            preamble_J = (
-                node.profile.preamble_current_a
-                * node.profile.voltage_v
-                * node.profile.preamble_time_s
-            )
-            self.total_energy_J += energy_J + preamble_J
-            self.energy_nodes_J += energy_J + preamble_J
-            if preamble_J > 0.0:
-                node.add_energy(preamble_J, "preamble")
+            prev = node.energy_consumed
             node.add_energy(energy_J, "tx")
+            delta = node.energy_consumed - prev
+            self.total_energy_J += delta
+            self.energy_nodes_J += delta
             if not node.alive:
                 return True
             node.state = "tx"

--- a/tests/test_energy_accounting.py
+++ b/tests/test_energy_accounting.py
@@ -16,9 +16,22 @@ def test_tx_energy_accounted_once():
     )
     sim.run()
     node = sim.nodes[0]
-    expected = (
-        node.profile.get_tx_current(node.tx_power)
-        * node.profile.voltage_v
-        * node.channel.airtime(node.sf, payload_size=sim.payload_size_bytes)
+    current = node.profile.get_tx_current(node.tx_power)
+    airtime = node.channel.airtime(node.sf, payload_size=sim.payload_size_bytes)
+    expected_tx = current * node.profile.voltage_v * (
+        airtime + node.profile.ramp_up_s + node.profile.ramp_down_s
     )
-    assert node.energy_tx == pytest.approx(expected)
+    assert node.energy_tx == pytest.approx(expected_tx)
+    expected_startup = (
+        node.profile.startup_current_a
+        * node.profile.voltage_v
+        * node.profile.startup_time_s
+        * 2
+    )
+    expected_preamble = (
+        node.profile.preamble_current_a
+        * node.profile.voltage_v
+        * node.profile.preamble_time_s
+    )
+    assert node.energy_startup == pytest.approx(expected_startup)
+    assert node.energy_preamble == pytest.approx(expected_preamble)

--- a/tests/test_flora_energy.py
+++ b/tests/test_flora_energy.py
@@ -1,0 +1,36 @@
+import pytest
+
+from simulateur_lora_sfrd.launcher.energy_profiles import EnergyProfile
+from simulateur_lora_sfrd.launcher.node import Node
+from simulateur_lora_sfrd.launcher.channel import Channel
+
+
+def test_cumulative_energy_matches_flora_model():
+    profile = EnergyProfile(
+        voltage_v=1.0,
+        startup_current_a=2.0,
+        startup_time_s=1.0,
+        preamble_current_a=3.0,
+        preamble_time_s=1.0,
+        ramp_up_s=1.0,
+        ramp_down_s=1.0,
+        tx_current_map_a={14.0: 4.0},
+    )
+    ch = Channel()
+    node = Node(0, 0.0, 0.0, sf=7, tx_power=14.0, channel=ch, energy_profile=profile)
+    airtime = 1.0
+    tx_energy = profile.get_tx_current(14.0) * profile.voltage_v * airtime
+    node.add_energy(tx_energy, "tx")
+    expected = (
+        tx_energy
+        + profile.get_tx_current(14.0) * profile.voltage_v * (profile.ramp_up_s + profile.ramp_down_s)
+        + profile.startup_current_a * profile.voltage_v * profile.startup_time_s
+        + profile.preamble_current_a * profile.voltage_v * profile.preamble_time_s
+    )
+    assert node.energy_consumed == pytest.approx(expected)
+    assert node.energy_startup == pytest.approx(
+        profile.startup_current_a * profile.voltage_v * profile.startup_time_s
+    )
+    assert node.energy_preamble == pytest.approx(
+        profile.preamble_current_a * profile.voltage_v * profile.preamble_time_s
+    )


### PR DESCRIPTION
## Summary
- Extend the default FLoRa energy profile with startup, preamble and PA ramp parameters
- Deduct startup, preamble and ramp energies for every transmission in `Node.add_energy`
- Add regression tests validating cumulative energy against FLoRa-style calculations
- Fix ADR standard configuration so detection thresholds match FLoRa values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dee216ba083319830a37f065bf4eb