### PR TITLE
Add RandomWaypoint mobility test

### DIFF
--- a/tests/test_random_waypoint_mobility.py
+++ b/tests/test_random_waypoint_mobility.py
@@ -1,0 +1,14 @@
+from simulateur_lora_sfrd.launcher.random_waypoint import RandomWaypoint
+from simulateur_lora_sfrd.launcher.node import Node
+
+
+def test_random_waypoint_move_within_bounds_and_updates_time():
+    mobility = RandomWaypoint(area_size=100.0, min_speed=1.0, max_speed=1.0)
+    node = Node(0, 50.0, 50.0, 7, 14)
+
+    mobility.assign(node)
+    mobility.move(node, 10.0)
+
+    assert 0.0 <= node.x <= 100.0
+    assert 0.0 <= node.y <= 100.0
+    assert node.last_move_time == 10.0


### PR DESCRIPTION
## Summary
- add unit test for RandomWaypoint mobility to ensure nodes remain in bounds and timestamps update

## Testing
- `pytest tests/test_random_waypoint_mobility.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689e03e52a2483318ccedf26952a7c25