### PR TITLE
Add mobility multichannel simulation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,6 +715,7 @@ l'utilisation du simulateur :
 python examples/run_basic.py          # simulation rapide avec 20 nœuds
 python examples/run_basic.py --dump-intervals  # exporte les intervalles
 python examples/run_flora_example.py  # reproduction d'un scénario FLoRa
+python scripts/run_mobility_multichannel.py --nodes 50 --packets 100 --seed 1
 ```
 
 L'option `--dump-intervals` active `dump_interval_logs` : un fichier Parquet est

--- a/scripts/run_mobility_multichannel.py
+++ b/scripts/run_mobility_multichannel.py
@@ -1,0 +1,85 @@
+"""Run mobility and multi-channel simulation scenarios.
+
+This utility executes four predefined scenarios combining mobile/static nodes
+and single/three-channel configurations.  Metrics for each scenario are
+exported as CSV files under the ``results`` directory.
+
+Usage::
+
+    python scripts/run_mobility_multichannel.py --nodes 50 --packets 100 --seed 1
+"""
+
+import os
+import sys
+import argparse
+
+# Allow running the script from a clone without installation
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from simulateur_lora_sfrd.launcher import Simulator, MultiChannel  # noqa: E402
+
+try:  # pandas is optional but required for CSV export
+    import pandas as pd
+except Exception as exc:  # pragma: no cover - handled at runtime
+    raise SystemExit(f"pandas is required for this script: {exc}")
+
+
+RESULTS_DIR = os.path.join(os.path.dirname(__file__), "..", "results")
+
+
+def run_scenario(name: str, mobility: bool, channels: MultiChannel,
+                 num_nodes: int, packets: int, seed: int) -> None:
+    """Run a single scenario and save metrics to CSV."""
+    sim = Simulator(
+        num_nodes=num_nodes,
+        num_gateways=1,
+        packets_to_send=packets,
+        seed=seed,
+        mobility=mobility,
+        channels=channels,
+    )
+    sim.run()
+    metrics = sim.get_metrics()
+
+    os.makedirs(RESULTS_DIR, exist_ok=True)
+    out_path = os.path.join(RESULTS_DIR, f"mobility_multichannel_{name}.csv")
+    pd.json_normalize(metrics).to_csv(out_path, index=False)
+    print(f"Saved {out_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run mobility/static and multi-channel scenarios",
+    )
+    parser.add_argument("--nodes", type=int, default=50, help="Number of nodes")
+    parser.add_argument("--packets", type=int, default=100,
+                        help="Packets to send per node")
+    parser.add_argument("--seed", type=int, default=1, help="Random seed")
+    args = parser.parse_args()
+
+    scenarios = {
+        "static_single": {
+            "mobility": False,
+            "channels": MultiChannel([868100000.0]),
+        },
+        "static_three": {
+            "mobility": False,
+            "channels": MultiChannel([868100000.0, 868300000.0, 868500000.0]),
+        },
+        "mobile_single": {
+            "mobility": True,
+            "channels": MultiChannel([868100000.0]),
+        },
+        "mobile_three": {
+            "mobility": True,
+            "channels": MultiChannel([868100000.0, 868300000.0, 868500000.0]),
+        },
+    }
+
+    for name, params in scenarios.items():
+        run_scenario(name, params["mobility"], params["channels"],
+                     args.nodes, args.packets, args.seed)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `run_mobility_multichannel.py` to run four scenarios covering static/mobile nodes and single/three channels
- write per-scenario metrics to CSV files under `results/`
- document command-line usage for the new script in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e03efdc708331b41c221f796c94dc