### PR TITLE
Add battery tracking and plotting scripts

### DIFF
--- a/scripts/plot_battery_tracking.py
+++ b/scripts/plot_battery_tracking.py
@@ -1,0 +1,59 @@
+"""Plot battery evolution from ``results/battery_tracking.csv``.
+
+The CSV is expected to contain columns ``time``, ``node_id`` and ``energy_j`` as
+produced by ``run_battery_tracking.py``.  This utility draws the remaining energy
+of each node over time and also plots the average across nodes.  The figure is
+saved to ``figures/battery_tracking.png``.
+
+Usage::
+
+    python scripts/plot_battery_tracking.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Allow running the script from a clone without installation
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+try:  # pandas and matplotlib are optional but required for plotting
+    import pandas as pd
+    import matplotlib.pyplot as plt
+except Exception as exc:  # pragma: no cover - handled at runtime
+    raise SystemExit(f"Required plotting libraries missing: {exc}")
+
+RESULTS_DIR = os.path.join(os.path.dirname(__file__), "..", "results")
+FIGURES_DIR = os.path.join(os.path.dirname(__file__), "..", "figures")
+
+
+def main() -> None:
+    in_path = os.path.join(RESULTS_DIR, "battery_tracking.csv")
+    if not os.path.exists(in_path):
+        raise SystemExit(f"Input file not found: {in_path}")
+
+    df = pd.read_csv(in_path)
+    if not {"time", "node_id", "energy_j"} <= set(df.columns):
+        raise SystemExit("CSV must contain time, node_id and energy_j columns")
+
+    plt.figure()
+    for node_id, group in df.groupby("node_id"):
+        plt.plot(group["time"], group["energy_j"], label=f"Node {node_id}")
+
+    avg = df.groupby("time")["energy_j"].mean()
+    plt.plot(avg.index, avg.values, color="k", linewidth=2, label="Average")
+
+    plt.xlabel("Time (s)")
+    plt.ylabel("Energy (J)")
+    plt.grid(True)
+    plt.legend()
+
+    os.makedirs(FIGURES_DIR, exist_ok=True)
+    out_path = os.path.join(FIGURES_DIR, "battery_tracking.png")
+    plt.savefig(out_path)
+    print(f"Saved {out_path}")
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    main()

--- a/scripts/run_battery_tracking.py
+++ b/scripts/run_battery_tracking.py
@@ -1,0 +1,81 @@
+"""Run a small simulation and track battery levels after each event.
+
+This script executes the simulator step by step, collecting the remaining
+energy of each node after every processed event.  The collected data is stored
+in ``results/battery_tracking.csv`` with columns ``time``, ``node_id`` and
+``energy_j``.
+
+Usage::
+
+    python scripts/run_battery_tracking.py --nodes 5 --packets 3 --seed 1
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import argparse
+from typing import Iterable
+
+# Allow running the script from a clone without installation
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from simulateur_lora_sfrd.launcher import Simulator  # noqa: E402
+
+try:  # pandas is optional but required for CSV export
+    import pandas as pd
+except Exception as exc:  # pragma: no cover - handled at runtime
+    raise SystemExit(f"pandas is required for this script: {exc}")
+
+RESULTS_DIR = os.path.join(os.path.dirname(__file__), "..", "results")
+
+
+# Default battery capacity in joules for each node.  A finite value is required
+# to observe the remaining energy decreasing over time.
+DEFAULT_BATTERY_J = 1000.0
+
+
+def _collect(sim: Simulator) -> Iterable[dict[str, float | int]]:
+    """Yield a record for each node with current time and remaining energy."""
+    for node in sim.nodes:
+        # Prefer explicit battery attribute when available
+        energy = getattr(node, "battery_remaining_j", None)
+        if energy is None:
+            # Fallback to generic energy attributes if present
+            energy = getattr(node, "remaining_energy", None)
+        if energy is None:
+            energy = getattr(node, "energy_total", None)
+        if energy is None:
+            energy = getattr(node, "energy_consumed", 0.0)
+        yield {"time": sim.current_time, "node_id": node.id, "energy_j": energy}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Track node battery energy")
+    parser.add_argument("--nodes", type=int, default=5, help="Number of nodes")
+    parser.add_argument(
+        "--packets", type=int, default=3, help="Packets to send per node"
+    )
+    parser.add_argument("--seed", type=int, default=1, help="Random seed")
+    args = parser.parse_args()
+
+    sim = Simulator(
+        num_nodes=args.nodes,
+        packets_to_send=args.packets,
+        seed=args.seed,
+        battery_capacity_j=DEFAULT_BATTERY_J,
+    )
+
+    records: list[dict[str, float | int]] = []
+    while sim.event_queue and sim.running:
+        sim.run(max_steps=1)  # Process one event at a time
+        records.extend(_collect(sim))
+
+    os.makedirs(RESULTS_DIR, exist_ok=True)
+    out_path = os.path.join(RESULTS_DIR, "battery_tracking.csv")
+    pd.DataFrame(records).to_csv(out_path, index=False)
+    print(f"Saved {out_path}")
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    main()


### PR DESCRIPTION
## Summary
- add utility to run simulations step-by-step and log remaining battery energy per node
- add plotting helper to visualise energy over time for each node and average

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e718f22d48331840b8f2db5632171