### PR TITLE
Add battery tracking regression test

### DIFF
--- a/tests/test_battery_tracking.py
+++ b/tests/test_battery_tracking.py
@@ -1,0 +1,26 @@
+import pytest
+
+from simulateur_lora_sfrd.launcher.simulator import Simulator
+
+
+def test_battery_tracking():
+    sim = Simulator(num_nodes=3, packets_to_send=2, battery_capacity_j=1000, seed=1)
+
+    previous = {n.id: n.battery_remaining_j for n in sim.nodes}
+    prev_time = sim.current_time
+
+    while sim.event_queue:
+        sim.run(max_steps=1)
+        for n in sim.nodes:
+            n.consume_until(sim.current_time)
+        for n in sim.nodes:
+            assert n.battery_remaining_j <= previous[n.id] + 1e-9
+        if sim.current_time - prev_time > 1e-9:
+            assert any(
+                n.battery_remaining_j < previous[n.id] - 1e-9 for n in sim.nodes
+            )
+        previous = {n.id: n.battery_remaining_j for n in sim.nodes}
+        prev_time = sim.current_time
+
+    for n in sim.nodes:
+        assert n.battery_remaining_j < 1000


### PR DESCRIPTION
## Summary
- add test covering per-step battery depletion to ensure energy decreases and end levels drop below initial capacity

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1acf71ca88331a5ebc0bf8679a4f7