### PR TITLE
Add mobility energy per packet test

### DIFF
--- a/results/mobility_energy.csv
+++ b/results/mobility_energy.csv
@@ -1,0 +1,3 @@
+scenario,energy_J,packets_delivered,energy_per_packet
+single_channel,2.326947026134257,93,0.025020935764884483
+multi_channel,2.326947026134257,135,0.017236644638031533

--- a/tests/test_mobility_energy_per_packet.py
+++ b/tests/test_mobility_energy_per_packet.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from simulateur_lora_sfrd.launcher import MultiChannel, Simulator
+
+PARAMS = dict(
+    num_nodes=20,
+    area_size=100,
+    transmission_mode="Random",
+    packet_interval=1.0,
+    packets_to_send=10,
+    mobility=True,
+    seed=1,
+    fixed_sf=7,
+    battery_capacity_j=1000,
+)
+
+
+def run_sim(channels: MultiChannel) -> tuple[float, int]:
+    sim = Simulator(**PARAMS, channels=channels)
+    sim.run()
+    metrics = sim.get_metrics()
+    energy = metrics["energy_J"]
+    delivered = sim.packets_delivered
+    return energy, delivered
+
+
+def test_mobility_energy_per_packet() -> None:
+    single_channels = MultiChannel([868_100_000.0])
+    multi_channels = MultiChannel([868_100_000.0, 868_300_000.0, 868_500_000.0])
+
+    energy_single, delivered_single = run_sim(single_channels)
+    energy_multi, delivered_multi = run_sim(multi_channels)
+
+    assert delivered_single > 0 and delivered_multi > 0
+
+    energy_per_packet_single = energy_single / delivered_single
+    energy_per_packet_multi = energy_multi / delivered_multi
+
+    results_dir = Path(__file__).resolve().parent.parent / "results"
+    results_dir.mkdir(exist_ok=True)
+    with open(results_dir / "mobility_energy.csv", "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["scenario", "energy_J", "packets_delivered", "energy_per_packet"])
+        writer.writerow([
+            "single_channel",
+            energy_single,
+            delivered_single,
+            energy_per_packet_single,
+        ])
+        writer.writerow([
+            "multi_channel",
+            energy_multi,
+            delivered_multi,
+            energy_per_packet_multi,
+        ])
+
+    assert energy_per_packet_multi < energy_per_packet_single


### PR DESCRIPTION
## Summary
- add test for energy per packet in mobility scenarios
- log single vs multi-channel energy metrics to `results/mobility_energy.csv`

## Testing
- `pytest tests/test_mobility_energy_per_packet.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1c574e0988331b8d18a94ca87c9ba