### PR TITLE
Add script to generate figures and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -760,6 +760,29 @@ Les points suivants ont été intégrés au simulateur :
 - **Suivi détaillé des ACK.** Chaque nœud mémorise les confirmations reçues pour appliquer fidèlement la logique ADR de FLoRa.
 - **Scheduler de downlinks prioritaire.** Le module `downlink_scheduler.py` organise les transmissions B/C en donnant la priorité aux commandes et accusés de réception.
 
+## Reproduction des figures
+
+Pour générer toutes les figures fournies avec le projet, utilisez:
+
+```bash
+python scripts/generate_all_figures.py --nodes 50 --packets 100 --seed 1
+```
+
+Les paramètres peuvent aussi être définis dans un fichier INI:
+
+```bash
+python scripts/generate_all_figures.py --config mon_fichier.ini
+```
+
+Contenu minimal de `mon_fichier.ini` :
+
+```ini
+[simulation]
+nodes = 50
+packets = 100
+seed = 1
+```
+
 ## Limites actuelles
 
 Le simulateur reste volontairement léger et certaines fonctionnalités manquent

--- a/scripts/generate_all_figures.py
+++ b/scripts/generate_all_figures.py
@@ -1,0 +1,150 @@
+"""Generate all figures by running predefined simulation scripts.
+
+This utility sequentially executes several simulation and plotting scripts to
+reproduce the figures shipped with the project. Parameters such as the number
+of nodes, packets per node and the random seed can be provided either on the
+command line or via a configuration file.
+
+Examples
+--------
+Run with explicit arguments::
+
+    python scripts/generate_all_figures.py --nodes 50 --packets 100 --seed 1
+
+Run using a configuration file::
+
+    python scripts/generate_all_figures.py --config my_config.ini
+
+The configuration file should contain a section ``[simulation]`` with keys
+``nodes``, ``packets`` and ``seed``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import configparser
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+ROOT_DIR = SCRIPT_DIR.parent
+RESULTS_DIR = ROOT_DIR / "results"
+
+
+DEFAULTS = {"nodes": 50, "packets": 100, "seed": 1, "area_size": 1000.0}
+
+
+def load_config(path: str | None) -> dict:
+    params = DEFAULTS.copy()
+    if path:
+        config = configparser.ConfigParser()
+        config.read(path)
+        if "simulation" in config:
+            for key in params:
+                if key in config["simulation"]:
+                    raw = config["simulation"][key]
+                    params[key] = float(raw) if key == "area_size" else int(raw)
+    return params
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", help="Path to configuration file")
+    parser.add_argument("--nodes", type=int, help="Number of nodes")
+    parser.add_argument("--packets", type=int, help="Packets per node")
+    parser.add_argument("--seed", type=int, help="Random seed")
+    parser.add_argument("--area-size", type=float, help="Area size for node position plot")
+    args = parser.parse_args()
+
+    params = load_config(args.config)
+    for key in ("nodes", "packets", "seed", "area_size"):
+        value = getattr(args, key.replace("-", "_"), None)
+        if value is not None:
+            params[key] = value
+
+    python = sys.executable
+
+    subprocess.run(
+        [
+            python,
+            str(SCRIPT_DIR / "run_mobility_multichannel.py"),
+            "--nodes",
+            str(params["nodes"]),
+            "--packets",
+            str(params["packets"]),
+            "--seed",
+            str(params["seed"]),
+        ],
+        check=True,
+    )
+
+    subprocess.run(
+        [
+            python,
+            str(SCRIPT_DIR / "plot_mobility_multichannel.py"),
+            str(RESULTS_DIR / "mobility_multichannel.csv"),
+        ],
+        check=True,
+    )
+
+    subprocess.run(
+        [
+            python,
+            str(SCRIPT_DIR / "run_mobility_latency_energy.py"),
+            "--nodes",
+            str(params["nodes"]),
+            "--packets",
+            str(params["packets"]),
+            "--seed",
+            str(params["seed"]),
+        ],
+        check=True,
+    )
+
+    subprocess.run(
+        [
+            python,
+            str(SCRIPT_DIR / "plot_mobility_latency_energy.py"),
+            str(RESULTS_DIR / "mobility_latency_energy.csv"),
+        ],
+        check=True,
+    )
+
+    subprocess.run(
+        [
+            python,
+            str(SCRIPT_DIR / "run_battery_tracking.py"),
+            "--nodes",
+            str(params["nodes"]),
+            "--packets",
+            str(params["packets"]),
+            "--seed",
+            str(params["seed"]),
+        ],
+        check=True,
+    )
+
+    subprocess.run(
+        [python, str(SCRIPT_DIR / "plot_battery_tracking.py")],
+        check=True,
+    )
+
+    subprocess.run(
+        [
+            python,
+            str(SCRIPT_DIR / "plot_node_positions.py"),
+            "--num-nodes",
+            str(params["nodes"]),
+            "--area-size",
+            str(params["area_size"]),
+            "--seed",
+            str(params["seed"]),
+        ],
+        check=True,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `scripts/generate_all_figures.py` to orchestrate running and plotting existing simulations
- Document figure reproduction workflow in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4c9c8235c8331902d4d5f9444eaaf