### PR TITLE
Add replicates and ADR options with error bar plotting

### DIFF
--- a/scripts/run_mobility_multichannel.py
+++ b/scripts/run_mobility_multichannel.py
@@ -1,8 +1,9 @@
 """Run mobility and multi-channel simulation scenarios.
 
 This utility executes four predefined scenarios combining mobile/static nodes
-and single/three-channel configurations.  Metrics for each scenario are
-collected and saved to a single CSV file under the ``results`` directory.
+and single/three-channel configurations.  Each scenario may be repeated using
+``--replicates`` and the mean/standard deviation of key metrics are stored in
+``results/mobility_multichannel.csv``.
 
 Usage::
 
@@ -12,6 +13,7 @@ Usage::
 import os
 import sys
 import argparse
+from typing import List
 
 # Allow running the script from a clone without installation
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -27,8 +29,18 @@ except Exception as exc:  # pragma: no cover - handled at runtime
 RESULTS_DIR = os.path.join(os.path.dirname(__file__), "..", "results")
 
 
-def run_scenario(name: str, mobility: bool, channels: MultiChannel,
-                 num_nodes: int, packets: int, seed: int) -> dict:
+def run_scenario(
+    name: str,
+    mobility: bool,
+    channels: MultiChannel,
+    num_nodes: int,
+    packets: int,
+    seed: int,
+    adr_node: bool,
+    adr_server: bool,
+    area_size: float,
+    interval: float,
+) -> dict:
     """Run a single scenario and return its metrics."""
     sim = Simulator(
         num_nodes=num_nodes,
@@ -37,6 +49,10 @@ def run_scenario(name: str, mobility: bool, channels: MultiChannel,
         seed=seed,
         mobility=mobility,
         channels=channels,
+        adr_node=adr_node,
+        adr_server=adr_server,
+        area_size=area_size,
+        packet_interval=interval,
     )
     sim.run()
     metrics = sim.get_metrics()
@@ -49,9 +65,35 @@ def main() -> None:
         description="Run mobility/static and multi-channel scenarios",
     )
     parser.add_argument("--nodes", type=int, default=50, help="Number of nodes")
-    parser.add_argument("--packets", type=int, default=100,
-                        help="Packets to send per node")
+    parser.add_argument(
+        "--packets", type=int, default=100, help="Packets to send per node"
+    )
     parser.add_argument("--seed", type=int, default=1, help="Random seed")
+    parser.add_argument(
+        "--adr-node",
+        action="store_true",
+        help="Enable ADR algorithm on nodes",
+    )
+    parser.add_argument(
+        "--adr-server",
+        action="store_true",
+        help="Enable ADR algorithm on server",
+    )
+    parser.add_argument(
+        "--area-size",
+        type=float,
+        default=1000.0,
+        help="Square area size in metres",
+    )
+    parser.add_argument(
+        "--interval", type=float, default=60.0, help="Mean packet interval (s)"
+    )
+    parser.add_argument(
+        "--replicates",
+        type=int,
+        default=1,
+        help="Number of simulation replicates",
+    )
     args = parser.parse_args()
 
     scenarios = {
@@ -73,22 +115,42 @@ def main() -> None:
         },
     }
 
-    runs = []
+    rows: List[dict] = []
     for name, params in scenarios.items():
-        runs.append(
-            run_scenario(
-                name,
-                params["mobility"],
-                params["channels"],
-                args.nodes,
-                args.packets,
-                args.seed,
+        replicates = []
+        for r in range(args.replicates):
+            replicates.append(
+                run_scenario(
+                    name,
+                    params["mobility"],
+                    params["channels"],
+                    args.nodes,
+                    args.packets,
+                    args.seed + r,
+                    args.adr_node,
+                    args.adr_server,
+                    args.area_size,
+                    args.interval,
+                )
             )
-        )
+
+        df = pd.DataFrame(replicates)
+        total_packets = df["delivered"] + df["collisions"]
+        df["pdr"] = df["delivered"] / total_packets * 100
+        df["collision_rate"] = df["collisions"] / total_packets * 100
+        df["energy_per_node"] = df["energy_nodes_J"] / args.nodes
+
+        stats = {"scenario": name}
+        for col in ["pdr", "collision_rate", "avg_delay_s", "energy_per_node"]:
+            mean = df[col].mean()
+            std = df[col].std(ddof=0)
+            stats[f"{col}_mean"] = mean
+            stats[f"{col}_std"] = std
+        rows.append(stats)
 
     os.makedirs(RESULTS_DIR, exist_ok=True)
     out_path = os.path.join(RESULTS_DIR, "mobility_multichannel.csv")
-    pd.DataFrame(runs).to_csv(out_path, index=False)
+    pd.DataFrame(rows).to_csv(out_path, index=False)
     print(f"Saved {out_path}")
 
 


### PR DESCRIPTION
## Summary
- extend mobility experiment scripts with ADR toggles, area/interval controls and replicate support averaging metrics
- revise plotting utilities to render error bars and include collision and delay comparisons

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4faa2a4288331848f86a2bc681cbc