### PR TITLE
Improve bar plot legends for mobility scripts

### DIFF
--- a/scripts/plot_mobility_latency_energy.py
+++ b/scripts/plot_mobility_latency_energy.py
@@ -47,13 +47,19 @@ def plot(csv_path: str, output_dir: str = "figures") -> None:
             continue
         fig, ax = plt.subplots()
         bars = ax.bar(
-            df["scenario"], df[mean_col], yerr=df[std_col], capsize=4, color=color
+            df["scenario"],
+            df[mean_col],
+            yerr=df[std_col],
+            capsize=4,
+            color=color,
+            label=ylabel,
         )
         ax.set_xlabel("Scenario")
         ax.set_ylabel(ylabel)
         ax.set_title(f"{ylabel} by scenario")
-        ax.bar_label(bars, fmt=fmt)
-        fig.tight_layout()
+        ax.bar_label(bars, fmt=fmt, label_type="center")
+        ax.legend(loc="center left", bbox_to_anchor=(1, 0.5))
+        fig.tight_layout(rect=[0, 0, 0.85, 1])
         fig.savefig(out_dir / filename)
         plt.close(fig)
 

--- a/scripts/plot_mobility_multichannel.py
+++ b/scripts/plot_mobility_multichannel.py
@@ -47,12 +47,14 @@ def plot(csv_path: str, output_dir: str = "figures") -> None:
             yerr=df[std_col],
             capsize=4,
             color=color,
+            label=ylabel,
         )
         ax.set_xlabel("Scenario")
         ax.set_ylabel(ylabel)
         ax.set_title(f"{ylabel} by scenario")
-        ax.bar_label(bars, fmt=fmt)
-        fig.tight_layout()
+        ax.bar_label(bars, fmt=fmt, label_type="center")
+        ax.legend(loc="center left", bbox_to_anchor=(1, 0.5))
+        fig.tight_layout(rect=[0, 0, 0.85, 1])
         fig.savefig(out_dir / f"{metric}_vs_scenario.png")
         plt.close(fig)
 


### PR DESCRIPTION
## Summary
- center bar labels in mobility plotting scripts
- display legends to the right of plots and reserve layout space

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a674c681408331b6f18815b083f319