### PR TITLE
Add mobility model comparison scripts and automate figure generation

### DIFF
--- a/scripts/generate_all_figures.py
+++ b/scripts/generate_all_figures.py
@@ -115,6 +115,29 @@ def main() -> None:
     subprocess.run(
         [
             python,
+            str(SCRIPT_DIR / "run_mobility_models.py"),
+            "--nodes",
+            str(params["nodes"]),
+            "--packets",
+            str(params["packets"]),
+            "--seed",
+            str(params["seed"]),
+        ],
+        check=True,
+    )
+
+    subprocess.run(
+        [
+            python,
+            str(SCRIPT_DIR / "plot_mobility_models.py"),
+            str(RESULTS_DIR / "mobility_models.csv"),
+        ],
+        check=True,
+    )
+
+    subprocess.run(
+        [
+            python,
             str(SCRIPT_DIR / "run_battery_tracking.py"),
             "--nodes",
             str(params["nodes"]),

--- a/scripts/plot_mobility_models.py
+++ b/scripts/plot_mobility_models.py
@@ -1,0 +1,101 @@
+"""Plot metrics comparing mobility models from mobility_models.csv.
+
+Usage::
+
+    python scripts/plot_mobility_models.py results/mobility_models.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+
+def plot(
+    csv_path: str,
+    output_dir: str = "figures",
+    max_delay: float | None = None,
+    max_energy: float | None = None,
+) -> None:
+    df = pd.read_csv(csv_path)
+
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    metrics = [
+        ("pdr", "PDR", "%", "%.1f%%", "C0"),
+        ("collision_rate", "Collision rate", "%", "%.1f%%", "C1"),
+        ("avg_delay", "Average delay", "s", "%.2f s", "C2"),
+        ("energy_per_node", "Average energy per node", "J", "%.2f J", "C3"),
+    ]
+
+    for metric, name, unit, fmt, color in metrics:
+        mean_col = f"{metric}_mean"
+        std_col = f"{metric}_std"
+        if mean_col not in df.columns:
+            continue
+        fig, ax = plt.subplots()
+        label = f"{name} ({unit})"
+        bars = ax.bar(
+            df["model"],
+            df[mean_col],
+            yerr=df[std_col],
+            capsize=4,
+            color=color,
+            label=label,
+        )
+        ax.set_xlabel("Mobility model")
+        ax.set_ylabel(label)
+
+        if metric in {"pdr", "collision_rate"}:
+            cap = 100.0
+            ax.set_ylim(0, cap)
+            ax.axhline(cap, linestyle="--", color="grey", label="100 %")
+        elif metric == "avg_delay":
+            cap = max_delay or df[mean_col].max() * 1.1
+            ax.set_ylim(0, cap)
+        elif metric == "energy_per_node":
+            cap = max_energy or df[mean_col].max() * 1.1
+            ax.set_ylim(0, cap)
+        else:
+            cap = df[mean_col].max() * 1.1
+            ax.set_ylim(0, cap)
+
+        ax.set_title(f"{name} by model (0 ≤ {name} ≤ {cap:g} {unit})")
+        ax.bar_label(bars, fmt=fmt, label_type="center")
+        ax.legend(loc="center left", bbox_to_anchor=(1, 0.5))
+        fig.tight_layout(rect=[0, 0, 0.85, 1])
+        fig.savefig(out_dir / f"{metric}_vs_model.png")
+        plt.close(fig)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("csv", help="Path to mobility_models.csv")
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        default="figures",
+        help="Directory to save figures",
+    )
+    parser.add_argument(
+        "--max-delay",
+        type=float,
+        default=None,
+        help="Y-axis maximum for average delay plots",
+    )
+    parser.add_argument(
+        "--max-energy",
+        type=float,
+        default=None,
+        help="Y-axis maximum for energy plots",
+    )
+    args = parser.parse_args(argv)
+    plot(args.csv, args.output_dir, args.max_delay, args.max_energy)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_mobility_models.py
+++ b/scripts/run_mobility_models.py
@@ -1,0 +1,158 @@
+"""Run simulations comparing different mobility models.
+
+This utility executes scenarios for various node mobility models, collecting
+PDR, collision rate, average delay and per-node energy consumption. The
+aggregated metrics for each model are written to
+``results/mobility_models.csv``.
+
+Usage::
+
+    python scripts/run_mobility_models.py --nodes 50 --packets 100 --seed 1
+    python scripts/run_mobility_models.py --model random_waypoint --model smooth
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import statistics
+import sys
+from typing import Callable, Dict
+
+# Allow running the script from a clone without installation
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from simulateur_lora_sfrd.launcher import (
+    MultiChannel,
+    Simulator,
+    RandomWaypoint,
+    SmoothMobility,
+    PlannedRandomWaypoint,
+)
+
+RESULTS_DIR = os.path.join(os.path.dirname(__file__), "..", "results")
+
+
+def create_models(area_size: float) -> Dict[str, Callable[[], object]]:
+    """Return factory functions for supported mobility models."""
+    def planned_factory() -> PlannedRandomWaypoint:
+        model = PlannedRandomWaypoint(
+            area_size, terrain=[[1.0] * 10 for _ in range(10)]
+        )
+        model.step = 1.0
+        return model
+
+    return {
+        "random_waypoint": lambda: RandomWaypoint(area_size),
+        "smooth": lambda: SmoothMobility(area_size),
+        "planned": planned_factory,
+    }
+
+
+def run_model(
+    name: str,
+    factory: Callable[[], object],
+    num_nodes: int,
+    packets: int,
+    seed: int,
+    adr_node: bool,
+    adr_server: bool,
+    area_size: float,
+    interval: float,
+) -> dict:
+    """Run a single mobility model and return selected metrics."""
+    mobility_model = factory()
+    sim = Simulator(
+        num_nodes=num_nodes,
+        num_gateways=1,
+        packets_to_send=packets,
+        seed=seed,
+        mobility=True,
+        mobility_model=mobility_model,
+        channels=MultiChannel([868100000.0]),
+        adr_node=adr_node,
+        adr_server=adr_server,
+        area_size=area_size,
+        packet_interval=interval,
+    )
+    sim.run()
+    metrics = sim.get_metrics()
+    total_packets = metrics["delivered"] + metrics["collisions"]
+    return {
+        "model": name,
+        "pdr": metrics["PDR"] * 100,
+        "avg_delay": metrics["avg_delay_s"],
+        "energy_per_node": metrics["energy_nodes_J"] / num_nodes,
+        "collision_rate": metrics["collisions"] / total_packets * 100 if total_packets else 0.0,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run simulations for multiple mobility models")
+    parser.add_argument("--nodes", type=int, default=50, help="Number of nodes")
+    parser.add_argument("--packets", type=int, default=100, help="Packets per node")
+    parser.add_argument("--seed", type=int, default=1, help="Random seed")
+    parser.add_argument("--adr-node", action="store_true", help="Enable ADR on nodes")
+    parser.add_argument("--adr-server", action="store_true", help="Enable ADR on server")
+    parser.add_argument("--area-size", type=float, default=1000.0, help="Square area size in metres")
+    parser.add_argument("--interval", type=float, default=60.0, help="Mean packet interval (s)")
+    parser.add_argument("--replicates", type=int, default=1, help="Number of simulation replicates")
+    parser.add_argument(
+        "--model",
+        action="append",
+        choices=["random_waypoint", "smooth", "planned"],
+        help="Mobility model to simulate (may be repeated). Defaults to all.",
+    )
+    args = parser.parse_args()
+
+    factories = create_models(args.area_size)
+    models = args.model or list(factories.keys())
+
+    rows: list[dict] = []
+    for model_name in models:
+        factory = factories[model_name]
+        rep_rows = []
+        for r in range(args.replicates):
+            rep_rows.append(
+                run_model(
+                    model_name,
+                    factory,
+                    args.nodes,
+                    args.packets,
+                    args.seed + r,
+                    args.adr_node,
+                    args.adr_server,
+                    args.area_size,
+                    args.interval,
+                )
+            )
+        agg = {"model": model_name}
+        for key in ["pdr", "collision_rate", "avg_delay", "energy_per_node"]:
+            values = [row[key] for row in rep_rows]
+            agg[f"{key}_mean"] = statistics.mean(values)
+            agg[f"{key}_std"] = statistics.pstdev(values)
+        rows.append(agg)
+
+    os.makedirs(RESULTS_DIR, exist_ok=True)
+    out_path = os.path.join(RESULTS_DIR, "mobility_models.csv")
+    fieldnames = [
+        "model",
+        "pdr_mean",
+        "pdr_std",
+        "collision_rate_mean",
+        "collision_rate_std",
+        "avg_delay_mean",
+        "avg_delay_std",
+        "energy_per_node_mean",
+        "energy_per_node_std",
+    ]
+    with open(out_path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+    print(f"Saved {out_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `run_mobility_models.py` to simulate multiple mobility models and export metrics
- add `plot_mobility_models.py` for bar charts comparing models
- update `generate_all_figures.py` to run the new scripts

## Testing
- `python scripts/run_mobility_models.py --nodes 1 --packets 1 --seed 1`
- `python scripts/plot_mobility_models.py results/mobility_models.csv`
- `python -m py_compile scripts/run_mobility_models.py scripts/plot_mobility_models.py`
- `pytest tests/test_random_waypoint_mobility.py tests/test_smooth_mobility_rng.py tests/test_planned_random_waypoint.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a72d2bd7c083318d72f7fd757044ac