### PR TITLE
Add channel sweep utilities

### DIFF
--- a/scripts/plot_channels_sweep.py
+++ b/scripts/plot_channels_sweep.py
@@ -1,0 +1,60 @@
+"""Plot PDR and collisions as a function of channel count.
+
+This utility reads ``results/channels_summary.csv`` produced by
+``run_channels_sweep.py`` and plots the average packet delivery ratio and
+collisions for each number of channels.  The figure is saved to
+``figures/pdr_collisions_vs_channels.png``.
+
+Usage::
+
+    python scripts/plot_channels_sweep.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+try:  # pandas and matplotlib are optional but required for plotting
+    import pandas as pd
+    import matplotlib.pyplot as plt
+except Exception as exc:  # pragma: no cover - handled at runtime
+    raise SystemExit(f"Required plotting libraries missing: {exc}")
+
+RESULTS_DIR = os.path.join(os.path.dirname(__file__), "..", "results")
+FIGURES_DIR = os.path.join(os.path.dirname(__file__), "..", "figures")
+
+
+def main() -> None:
+    in_path = os.path.join(RESULTS_DIR, "channels_summary.csv")
+    if not os.path.exists(in_path):
+        raise SystemExit(f"Input file not found: {in_path}")
+
+    df = pd.read_csv(in_path)
+    required = {"channels", "PDR(%)", "collisions"}
+    if not required <= set(df.columns):
+        raise SystemExit("CSV must contain channels, PDR(%) and collisions columns")
+
+    stats = df.groupby("channels")[["PDR(%)", "collisions"]].mean().reset_index()
+
+    fig, ax1 = plt.subplots()
+    ax2 = ax1.twinx()
+
+    ax1.plot(stats["channels"], stats["PDR(%)"], marker="o", color="C0")
+    ax2.plot(stats["channels"], stats["collisions"], marker="s", color="C1")
+
+    ax1.set_xlabel("channels")
+    ax1.set_ylabel("PDR(%)", color="C0")
+    ax2.set_ylabel("collisions", color="C1")
+    ax1.tick_params(axis="y", labelcolor="C0")
+    ax2.tick_params(axis="y", labelcolor="C1")
+
+    fig.tight_layout()
+    os.makedirs(FIGURES_DIR, exist_ok=True)
+    out_path = os.path.join(FIGURES_DIR, "pdr_collisions_vs_channels.png")
+    fig.savefig(out_path)
+    print(f"Saved {out_path}")
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    main()

--- a/scripts/run_channels_sweep.py
+++ b/scripts/run_channels_sweep.py
@@ -1,0 +1,67 @@
+"""Run LoRa simulations sweeping the number of channels.
+
+This helper executes ``simulateur_lora_sfrd/run.py`` for multiple channel
+counts and stores the resulting metrics in individual CSV files under
+``results``.  The per-channel CSVs are then concatenated into
+``results/channels_summary.csv``.
+
+Usage::
+
+    python scripts/run_channels_sweep.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import subprocess
+
+try:  # pandas is optional but required for CSV handling
+    import pandas as pd
+except Exception as exc:  # pragma: no cover - handled at runtime
+    raise SystemExit(f"pandas is required for this script: {exc}")
+
+RESULTS_DIR = os.path.join(os.path.dirname(__file__), "..", "results")
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+def main() -> None:
+    channels_list = [1, 3, 5]
+    csv_files: list[str] = []
+    os.makedirs(RESULTS_DIR, exist_ok=True)
+
+    for ch in channels_list:
+        out_file = os.path.join(RESULTS_DIR, f"channels_{ch}.csv")
+        cmd = [
+            sys.executable,
+            os.path.join(ROOT_DIR, "simulateur_lora_sfrd", "run.py"),
+            "--nodes",
+            "30",
+            "--gateways",
+            "1",
+            "--steps",
+            "500",
+            "--mode",
+            "random",
+            "--interval",
+            "10",
+            "--seed",
+            "1",
+            "--runs",
+            "5",
+            "--channels",
+            str(ch),
+            "--output",
+            out_file,
+        ]
+        subprocess.run(cmd, check=True, cwd=ROOT_DIR)
+        csv_files.append(out_file)
+
+    df = pd.concat((pd.read_csv(p) for p in csv_files), ignore_index=True)
+    summary_path = os.path.join(RESULTS_DIR, "channels_summary.csv")
+    df.to_csv(summary_path, index=False)
+    print(f"Saved {summary_path}")
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    main()


### PR DESCRIPTION
## Summary
- Add script to run simulator for varying channel counts and aggregate CSV outputs
- Add plotting utility to visualize PDR and collisions versus channels

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7554322a08331a033637ff485261b