### PR TITLE
Add interval sweep scripts for traffic interval analysis

### DIFF
--- a/scripts/plot_interval_sweep.py
+++ b/scripts/plot_interval_sweep.py
@@ -1,0 +1,50 @@
+"""Plot PDR and collisions versus packet interval.
+
+This script reads ``results/interval_summary.csv`` produced by
+``scripts/run_interval_sweep.py``.  It computes the mean ``PDR(%)`` and
+``collisions`` for each interval and generates a two-panel figure saved to
+``figures/pdr_collisions_vs_interval.png``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+RESULTS_DIR = ROOT / "results"
+FIGURES_DIR = ROOT / "figures"
+
+
+def main() -> None:
+    summary_path = RESULTS_DIR / "interval_summary.csv"
+    df = pd.read_csv(summary_path)
+    agg = (
+        df.groupby("interval")[["PDR(%)", "collisions"]]
+        .mean()
+        .reset_index()
+        .sort_values("interval")
+    )
+
+    FIGURES_DIR.mkdir(exist_ok=True)
+    fig, axes = plt.subplots(2, 1, figsize=(6, 6), sharex=True)
+
+    axes[0].plot(agg["interval"], agg["PDR(%)"], marker="o")
+    axes[0].set_ylabel("PDR (%)")
+    axes[0].set_title("PDR vs Interval")
+
+    axes[1].plot(agg["interval"], agg["collisions"], marker="o")
+    axes[1].set_ylabel("Collisions")
+    axes[1].set_xlabel("Interval")
+    axes[1].set_title("Collisions vs Interval")
+
+    fig.tight_layout()
+    out_path = FIGURES_DIR / "pdr_collisions_vs_interval.png"
+    fig.savefig(out_path)
+    print(f"Saved {out_path}")
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    main()

--- a/scripts/run_interval_sweep.py
+++ b/scripts/run_interval_sweep.py
@@ -1,0 +1,76 @@
+"""Run a sweep over different traffic intervals.
+
+This utility executes the base simulator for a set of packet interval values
+and collects the per-run metrics produced by ``simulateur_lora_sfrd/run.py``.
+Results for each interval are stored in ``results/interval_<IV>.csv`` and all
+rows are aggregated into ``results/interval_summary.csv``.
+"""
+
+from __future__ import annotations
+
+import csv
+import subprocess
+from pathlib import Path
+
+# Paths relative to repository root
+ROOT = Path(__file__).resolve().parents[1]
+RESULTS_DIR = ROOT / "results"
+
+
+def main() -> None:
+    intervals = [20, 10, 5]
+    RESULTS_DIR.mkdir(exist_ok=True)
+    csv_paths: list[Path] = []
+
+    for iv in intervals:
+        out_file = RESULTS_DIR / f"interval_{iv}.csv"
+        cmd = [
+            "python",
+            "-m",
+            "simulateur_lora_sfrd.run",
+            "--nodes",
+            "30",
+            "--gateways",
+            "1",
+            "--channels",
+            "3",
+            "--steps",
+            "500",
+            "--mode",
+            "random",
+            "--seed",
+            "2",
+            "--runs",
+            "5",
+            "--interval",
+            str(iv),
+            "--output",
+            str(out_file),
+        ]
+        subprocess.run(cmd, check=True)
+        csv_paths.append(out_file)
+
+    # Merge the individual CSV files into a single summary
+    summary_path = RESULTS_DIR / "interval_summary.csv"
+    header: list[str] | None = None
+    rows: list[list[str]] = []
+    for path in csv_paths:
+        with open(path, newline="") as f:
+            reader = csv.reader(f)
+            file_header = next(reader)
+            if header is None:
+                header = file_header
+            rows.extend(list(reader))
+
+    if header is None:
+        raise RuntimeError("No data collected")
+
+    with open(summary_path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(header)
+        writer.writerows(rows)
+    print(f"Saved {summary_path}")
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    main()


### PR DESCRIPTION
## Summary
- add `run_interval_sweep.py` to execute simulator over intervals 20, 10 and 5 and merge results
- add `plot_interval_sweep.py` to average PDR and collisions per interval and save figure

## Testing
- `python scripts/run_interval_sweep.py`
- `python scripts/plot_interval_sweep.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a75549d48483319fafaec9f9d6120c