### PR TITLE
Add noise sweep simulation and plotting scripts

### DIFF
--- a/scripts/plot_noise_sweep.py
+++ b/scripts/plot_noise_sweep.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Plot PDR against noise standard deviation."""
+
+from __future__ import annotations
+
+import csv
+import os
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+# Allow running the script from a clone without installation
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+RESULTS_DIR = Path(__file__).resolve().parent.parent / "results"
+FIGURES_DIR = Path(__file__).resolve().parent.parent / "figures"
+
+
+def main() -> None:
+    summary_file = RESULTS_DIR / "noise_summary.csv"
+    pdr_map: dict[float, list[float]] = defaultdict(list)
+    with summary_file.open() as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            ns = float(row["noise_std"])
+            pdr_map[ns].append(float(row["PDR(%)"]))
+
+    noise_levels = sorted(pdr_map.keys())
+    mean_pdr = [sum(pdr_map[ns]) / len(pdr_map[ns]) for ns in noise_levels]
+
+    FIGURES_DIR.mkdir(parents=True, exist_ok=True)
+    fig, ax = plt.subplots()
+    ax.plot(noise_levels, mean_pdr, marker="o")
+    ax.set_xlabel("noise_std")
+    ax.set_ylabel("PDR(%)")
+    ax.set_title("PDR vs Noise")
+    output_path = FIGURES_DIR / "pdr_vs_noise.png"
+    fig.savefig(output_path)
+    plt.close(fig)
+    print(f"Saved {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_noise_sweep.py
+++ b/scripts/run_noise_sweep.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Run simulations for different noise levels and aggregate results."""
+
+from __future__ import annotations
+
+import csv
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Allow running the script from a clone without installation
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+RESULTS_DIR = Path(__file__).resolve().parent.parent / "results"
+
+
+def run_noise_level(noise_std: float) -> list[dict[str, str]]:
+    """Run the simulator for a given noise standard deviation."""
+    output_file = RESULTS_DIR / f"noise_{int(noise_std)}.csv"
+    cmd = [
+        sys.executable,
+        "-m",
+        "simulateur_lora_sfrd.run",
+        "--nodes",
+        "30",
+        "--gateways",
+        "1",
+        "--channels",
+        "3",
+        "--steps",
+        "500",
+        "--mode",
+        "random",
+        "--interval",
+        "10",
+        "--seed",
+        "3",
+        "--runs",
+        "5",
+        "--noise-std",
+        str(noise_std),
+        "--output",
+        str(output_file),
+    ]
+    subprocess.run(cmd, check=True)
+    with output_file.open() as f:
+        rows = list(csv.DictReader(f))
+        for row in rows:
+            row["noise_std"] = str(noise_std)
+    return rows
+
+
+def main() -> None:
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    all_rows: list[dict[str, str]] = []
+    for ns in [0, 1, 2]:
+        all_rows.extend(run_noise_level(ns))
+
+    summary_file = RESULTS_DIR / "noise_summary.csv"
+    if all_rows:
+        fieldnames = ["noise_std"] + [
+            "nodes",
+            "gateways",
+            "channels",
+            "mode",
+            "interval",
+            "steps",
+            "run",
+            "delivered",
+            "collisions",
+            "PDR(%)",
+            "energy_J",
+            "avg_delay",
+            "throughput_bps",
+        ]
+        with summary_file.open("w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(all_rows)
+        print(f"Saved {summary_file}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `run_noise_sweep.py` to run simulator across multiple noise levels and gather CSV results
- add `plot_noise_sweep.py` to average PDR by noise level and plot to a PNG figure

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7554eb8a8833195b93f85895a17d6