### PR TITLE
Widen mobility plotting figures for clearer labels

### DIFF
--- a/scripts/plot_mobility_latency_energy.py
+++ b/scripts/plot_mobility_latency_energy.py
@@ -72,7 +72,7 @@ def plot(
         std_col = f"{metric}_std"
         if mean_col not in df.columns:
             continue
-        fig, ax = plt.subplots(figsize=(10, 6))
+        fig, ax = plt.subplots(figsize=(12, 6))
         label = f"{name} ({unit})"
         bars = ax.bar(
             df["scenario"],
@@ -107,7 +107,7 @@ def plot(
         ax.set_title(title)
         ax.bar_label(bars, fmt=fmt, label_type="center")
         ax.legend(loc="center left", bbox_to_anchor=(1, 0.5))
-        fig.tight_layout(rect=[0, 0.15, 0.85, 1])
+        fig.tight_layout(rect=[0, 0.2, 0.9, 1])
         fig.savefig(out_dir / filename)
         plt.close(fig)
 

--- a/scripts/plot_mobility_multichannel.py
+++ b/scripts/plot_mobility_multichannel.py
@@ -54,7 +54,7 @@ def plot(
         std_col = f"{metric}_std"
         if mean_col not in df.columns:
             continue
-        fig, ax = plt.subplots(figsize=(10, 6))
+        fig, ax = plt.subplots(figsize=(12, 6))
         label = f"{name} ({unit})"
         bars = ax.bar(
             df["scenario"],
@@ -89,7 +89,7 @@ def plot(
         ax.set_title(title)
         ax.bar_label(bars, fmt=fmt, label_type="center")
         ax.legend(loc="center left", bbox_to_anchor=(1, 0.5))
-        fig.tight_layout(rect=[0, 0.15, 0.85, 1])
+        fig.tight_layout(rect=[0, 0.2, 0.9, 1])
         fig.savefig(out_dir / f"{metric}_vs_scenario.png")
         plt.close(fig)
 


### PR DESCRIPTION
## Summary
- enlarge mobility plot figures to 12×6 inches for better tick spacing
- allocate extra bottom margin via `tight_layout(rect=[0,0.2,0.9,1])`
- keep rotated x-axis tick labels for readability across scenarios

## Testing
- `python scripts/plot_mobility_multichannel.py results/mobility_multichannel.csv -o figures`
- `python scripts/plot_mobility_latency_energy.py results/mobility_latency_energy.csv -o figures`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7882fe780833191e480be02da3998