### PR TITLE
Add average SF plotting and integrate into figure generation

### DIFF
--- a/scripts/generate_all_figures.py
+++ b/scripts/generate_all_figures.py
@@ -115,6 +115,15 @@ def main() -> None:
     subprocess.run(
         [
             python,
+            str(SCRIPT_DIR / "plot_sf_vs_scenario.py"),
+            str(RESULTS_DIR / "mobility_latency_energy.csv"),
+        ],
+        check=True,
+    )
+
+    subprocess.run(
+        [
+            python,
             str(SCRIPT_DIR / "run_mobility_models.py"),
             "--nodes",
             str(params["nodes"]),
@@ -130,6 +139,16 @@ def main() -> None:
         [
             python,
             str(SCRIPT_DIR / "plot_mobility_models.py"),
+            str(RESULTS_DIR / "mobility_models.csv"),
+        ],
+        check=True,
+    )
+
+    subprocess.run(
+        [
+            python,
+            str(SCRIPT_DIR / "plot_sf_vs_scenario.py"),
+            "--by-model",
             str(RESULTS_DIR / "mobility_models.csv"),
         ],
         check=True,

--- a/scripts/plot_sf_vs_scenario.py
+++ b/scripts/plot_sf_vs_scenario.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Plot average spreading factor by scenario or model.
+
+Usage::
+
+    python scripts/plot_sf_vs_scenario.py results/mobility_latency_energy.csv
+    python scripts/plot_sf_vs_scenario.py --by-model results/mobility_models.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+
+def plot(csv_path: str, output_dir: str = "figures", by_model: bool = False) -> None:
+    """Plot average spreading factor with error bars.
+
+    Parameters
+    ----------
+    csv_path:
+        Path to the CSV file containing the ``avg_sf_mean`` and ``avg_sf_std``
+        columns along with either ``scenario`` or ``model``.
+    output_dir:
+        Directory where the figure will be written.
+    by_model:
+        If ``True`` plot against the ``model`` column, otherwise use
+        ``scenario``.
+    """
+    df = pd.read_csv(csv_path)
+
+    x_col = "model" if by_model else "scenario"
+    required = {x_col, "avg_sf_mean", "avg_sf_std"}
+    if not required <= set(df.columns):
+        missing = ", ".join(sorted(required - set(df.columns)))
+        raise SystemExit(f"CSV must contain columns: {missing}")
+
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    fig, ax = plt.subplots(figsize=(12, 6))
+    x = range(len(df[x_col]))
+    bars = ax.bar(x, df["avg_sf_mean"], yerr=df["avg_sf_std"], capsize=4, color="C0")
+    ax.set_xticks(x)
+    ax.set_xticklabels(df[x_col], rotation=45, ha="right")
+    ax.set_xlabel("Mobility model" if by_model else "Scenario")
+    ax.set_ylabel("Average SF")
+    ax.set_title("Average SF by " + ("model" if by_model else "scenario"))
+    ax.bar_label(bars, fmt="%.2f", label_type="center")
+    fig.tight_layout()
+
+    filename = "avg_sf_vs_model.png" if by_model else "avg_sf_vs_scenario.png"
+    fig.savefig(out_dir / filename)
+    plt.close(fig)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("csv", help="Path to CSV file with average SF metrics")
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        default="figures",
+        help="Directory to save figures",
+    )
+    parser.add_argument(
+        "--by-model",
+        action="store_true",
+        help="Plot average SF versus mobility model",
+    )
+    args = parser.parse_args(argv)
+    plot(args.csv, args.output_dir, args.by_model)
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    main()


### PR DESCRIPTION
## Summary
- add `plot_sf_vs_scenario.py` to visualize average spreading factor across scenarios or mobility models
- wire new plot into `generate_all_figures.py` to generate both scenario and model charts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a78842a4d083318c781e0d86b9b8bc