### PR TITLE
Add average SF metric to mobility plots

### DIFF
--- a/scripts/plot_mobility_latency_energy.py
+++ b/scripts/plot_mobility_latency_energy.py
@@ -58,12 +58,12 @@ def plot(
             "avg_energy_per_node_vs_scenario.svg",
         ),
         (
-            "collision_rate",
-            "Collision rate",
-            "%",
-            "%.1f%%",
-            "C3",
-            "collision_rate_vs_scenario.svg",
+            "avg_sf",
+            "Average SF",
+            "",
+            "%.1f",
+            "C4",
+            "avg_sf_vs_scenario.svg",
         ),
     ]
 
@@ -72,12 +72,13 @@ def plot(
         std_col = f"{metric}_std"
         if mean_col not in df.columns:
             continue
+        yerr = df[std_col] if std_col in df.columns else None
         fig, ax = plt.subplots(figsize=(12, 6))
         label = f"{name} ({unit})"
         bars = ax.bar(
             df["scenario"],
             df[mean_col],
-            yerr=df[std_col],
+            yerr=yerr,
             capsize=4,
             color=color,
             label=label,
@@ -87,7 +88,7 @@ def plot(
         ax.set_xticklabels(df["scenario"], rotation=45, ha="right")
         ax.set_ylabel(label)
 
-        if metric in {"pdr", "collision_rate"}:
+        if metric == "pdr":
             cap = 100.0
             ax.set_ylim(0, cap)
             ax.axhline(cap, linestyle="--", color="grey", label="100 %")

--- a/scripts/plot_mobility_models.py
+++ b/scripts/plot_mobility_models.py
@@ -27,9 +27,9 @@ def plot(
 
     metrics = [
         ("pdr", "PDR", "%", "%.1f%%", "C0"),
-        ("collision_rate", "Collision rate", "%", "%.1f%%", "C1"),
         ("avg_delay", "Average delay", "s", "%.2f s", "C2"),
         ("energy_per_node", "Average energy per node", "J", "%.2f J", "C3"),
+        ("avg_sf", "Average SF", "", "%.1f", "C4"),
     ]
 
     for metric, name, unit, fmt, color in metrics:
@@ -37,12 +37,13 @@ def plot(
         std_col = f"{metric}_std"
         if mean_col not in df.columns:
             continue
+        yerr = df[std_col] if std_col in df.columns else None
         fig, ax = plt.subplots(figsize=(12, 6))
         label = f"{name} ({unit})"
         bars = ax.bar(
             df["model"],
             df[mean_col],
-            yerr=df[std_col],
+            yerr=yerr,
             capsize=4,
             color=color,
             label=label,
@@ -51,7 +52,7 @@ def plot(
         ax.set_xticklabels(df["model"], rotation=45, ha="right")
         ax.set_ylabel(label)
 
-        if metric in {"pdr", "collision_rate"}:
+        if metric == "pdr":
             cap = 100.0
             ax.set_ylim(0, cap)
             ax.axhline(cap, linestyle="--", color="grey", label="100 %")

--- a/scripts/plot_mobility_multichannel.py
+++ b/scripts/plot_mobility_multichannel.py
@@ -44,9 +44,9 @@ def plot(
 
     metrics = [
         ("pdr", "PDR", "%", "%.1f%%", "C0"),
-        ("collision_rate", "Collision rate", "%", "%.1f%%", "C1"),
         ("avg_delay_s", "Average delay", "s", "%.2f s", "C2"),
         ("energy_per_node", "Average energy per node", "J", "%.2f J", "C3"),
+        ("avg_sf", "Average SF", "", "%.1f", "C4"),
     ]
 
     for metric, name, unit, fmt, color in metrics:
@@ -54,12 +54,13 @@ def plot(
         std_col = f"{metric}_std"
         if mean_col not in df.columns:
             continue
+        yerr = df[std_col] if std_col in df.columns else None
         fig, ax = plt.subplots(figsize=(12, 6))
         label = f"{name} ({unit})"
         bars = ax.bar(
             df["scenario"],
             df[mean_col],
-            yerr=df[std_col],
+            yerr=yerr,
             capsize=4,
             color=color,
             label=label,
@@ -69,7 +70,7 @@ def plot(
         ax.set_xticklabels(df["scenario"], rotation=45, ha="right")
         ax.set_ylabel(label)
 
-        if metric in {"pdr", "collision_rate"}:
+        if metric == "pdr":
             cap = 100.0
             ax.set_ylim(0, cap)
             ax.axhline(cap, linestyle="--", color="grey", label="100 %")


### PR DESCRIPTION
## Summary
- remove collision rate metric from mobility plots
- add average SF plot support across mobility scripts
- handle missing standard deviation gracefully

## Testing
- `python scripts/plot_mobility_models.py /tmp/test_models.csv -o /tmp/figs_models`
- `ls /tmp/figs_models`
- `python scripts/plot_mobility_multichannel.py /tmp/test_multichannel.csv -o /tmp/figs_multi`
- `ls /tmp/figs_multi`
- `python scripts/plot_mobility_latency_energy.py /tmp/test_latency_energy.csv -o /tmp/figs_latency`
- `ls /tmp/figs_latency`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a78d4c25c48331a10499c6ddecc1a4