### PR TITLE
Support PathMobility model in mobility model runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,14 @@ Plusieurs schémas supplémentaires peuvent être utilisés :
 - `Trace3DMobility` lit une trace temporelle et suit le relief 3D en bloquant
   les passages au-dessus d'une hauteur maximale.
 
+Le script `scripts/run_mobility_models.py` peut comparer ces modèles. Pour
+utiliser `PathMobility`, fournissez la carte des chemins (fichier JSON ou CSV)
+avec `--path-map` :
+
+```bash
+python scripts/run_mobility_models.py --model path --path-map carte.json
+```
+
 ## Multi-canaux
 
 Le simulateur permet d'utiliser plusieurs canaux radio. Passez une instance


### PR DESCRIPTION
## Summary
- allow selecting `path` mobility model in `run_mobility_models.py`
- load path map via `--path-map` and instantiate `PathMobility`
- document new option in README

## Testing
- `pytest tests/test_path_mobility.py -q`
- `python scripts/run_mobility_models.py --nodes 1 --packets 1 --model random_waypoint`


------
https://chatgpt.com/codex/tasks/task_e_68a79c2f131083319893c46e11ef7ef5