### PR TITLE
Add test for path mobility model

### DIFF
--- a/tests/test_run_mobility_models_path.py
+++ b/tests/test_run_mobility_models_path.py
@@ -1,0 +1,37 @@
+import sys
+
+from scripts import run_mobility_models
+
+
+def test_run_mobility_models_path(tmp_path, monkeypatch):
+    # Create simple 2x2 path map with all cells traversable
+    map_file = tmp_path / "map.txt"
+    map_file.write_text("0 0\n0 0\n")
+
+    results_dir = tmp_path / "results"
+    monkeypatch.setattr(run_mobility_models, "RESULTS_DIR", results_dir)
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_mobility_models.py",
+            "--model",
+            "path",
+            "--path-map",
+            str(map_file),
+            "--nodes",
+            "1",
+            "--packets",
+            "1",
+            "--seed",
+            "1",
+        ],
+    )
+
+    run_mobility_models.main()
+
+    csv_file = results_dir / "mobility_models.csv"
+    assert csv_file.is_file()
+    lines = csv_file.read_text().splitlines()
+    assert lines[0].split(",")[0] + "," + lines[1].split(",")[0] == "model,path"


### PR DESCRIPTION
## Summary
- support `PathMobility` via `--model path` and `--path-map` options in `run_mobility_models.py`
- add regression test ensuring path model execution produces results CSV

## Testing
- `pytest tests/test_run_mobility_models_path.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a79c342ac0833193aa43ca7b484a1a