### PR TITLE
docs: rename simulator references

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ sensibilité. Un chemin personnalisé peut être fourni via `flora_noise_path`.
    > véritable bibliothèque NumPy est installée dans votre environnement.
 3. **Lancez le tableau de bord :**
 ```bash
-panel serve simulateur_lora_sfrd/launcher/dashboard.py --show
+panel serve loraflexsim/launcher/dashboard.py --show
 ```
 Définissez la valeur du champ **Graine** pour réutiliser le même placement de
 nœuds et la même suite d'intervalles pseudo‑aléatoires d'une simulation à
@@ -73,7 +73,7 @@ python run.py --lorawan-demo --steps 100 --output lorawan.csv
 Utilisez l'API Python pour tester les modes B et C :
 
 ```python
-from simulateur_lora_sfrd.launcher import Simulator
+from loraflexsim.launcher import Simulator
 
 # Nœuds en classe B avec slots réguliers
 sim_b = Simulator(num_nodes=10, node_class="B", beacon_interval=128,
@@ -91,7 +91,7 @@ sim_c.run(500)
 Les déplacements peuvent être rendus plus doux en ajustant la plage de vitesses :
 
 ```python
-from simulateur_lora_sfrd.launcher import Simulator
+from loraflexsim.launcher import Simulator
 
 sim = Simulator(num_nodes=20, num_gateways=3, area_size=2000.0, mobility=True,
                 mobility_speed=(1.0, 5.0))
@@ -295,7 +295,7 @@ réception :
   puissance reçue et le taux d'erreur.
 
 ```python
-from simulateur_lora_sfrd.launcher.channel import Channel
+from loraflexsim.launcher.channel import Channel
 canal = Channel(environment="urban")
 ```
 
@@ -308,7 +308,7 @@ qui combine ces effets avec un bruit thermique calibré.
 Il reprend les paramètres des fichiers INI de FLoRa, par exemple `sigma=3.57` pour le preset *flora*.
 
 ```python
-from simulateur_lora_sfrd.launcher.propagation_models import CompletePropagation
+from loraflexsim.launcher.propagation_models import CompletePropagation
 
 model = CompletePropagation(environment="flora", multipath_taps=3, fast_fading_std=1.0)
 loss = model.path_loss(1000)
@@ -354,7 +354,7 @@ de l'humidité peut également être activé grâce aux paramètres
 `humidity_percent` et `humidity_noise_coeff_dB`.
 
 ```python
-from simulateur_lora_sfrd.launcher.advanced_channel import AdvancedChannel
+from loraflexsim.launcher.advanced_channel import AdvancedChannel
 ch = AdvancedChannel(
     propagation_model="cost231_3d",
     terrain="suburban",
@@ -556,7 +556,7 @@ Pour reproduire un scénario FLoRa :
    (`multipath_taps=3`), un seuil de détection fixé à `-110 dBm` et une fenêtre
    d'interférence minimale de `5 s`. Le délai réseau est également de 10 ms avec
    un traitement serveur de 1,2 s comme dans OMNeT++.
-2. Appliquez l'algorithme ADR1 via `from simulateur_lora_sfrd.launcher.adr_standard_1 import apply as adr1` puis `adr1(sim, degrade_channel=True, profile="flora")`.
+2. Appliquez l'algorithme ADR1 via `from loraflexsim.launcher.adr_standard_1 import apply as adr1` puis `adr1(sim, degrade_channel=True, profile="flora")`.
    Cette fonction reprend la logique du serveur FLoRa original tout en
    remplaçant les canaux idéaux par des `AdvancedChannel` plus réalistes.
 3. Spécifiez `adr_method="avg"` lors de la création du `Simulator` (ou sur
@@ -687,7 +687,7 @@ Chaque entrée de `events_log` comporte `start_time` et `end_time` ; leur
 différence représente l'airtime réel du paquet.
 
 ```python
-from simulateur_lora_sfrd.launcher.channel import Channel
+from loraflexsim.launcher.channel import Channel
 ch = Channel()
 temps = ch.airtime(sf=7, payload_size=20)
 ```
@@ -721,7 +721,7 @@ Vous pouvez aussi comparer les métriques générées avec les formules théoriq
 
 ### Distribution des intervalles
 
-`timeToFirstPacket` et les inter-arrivals suivent la loi `Exp(1/µ_SFRD)`. Les tests `tests/test_interval_distribution.py` vérifient que la moyenne reste dans une tolérance de ±2 %, que le coefficient de variation est proche de 1 et que la p‑value du test de Kolmogorov–Smirnov dépasse 0,05. Le duty cycle et la gestion des collisions ne modifient pas cette distribution : seules les transmissions effectives sont retardées, comme le montrent `tests/test_poisson_independence.py`.
+`timeToFirstPacket` et les inter-arrivals suivent la loi `Exp(1/µ_LoRaFlexSim)`. Les tests `tests/test_interval_distribution.py` vérifient que la moyenne reste dans une tolérance de ±2 %, que le coefficient de variation est proche de 1 et que la p‑value du test de Kolmogorov–Smirnov dépasse 0,05. Le duty cycle et la gestion des collisions ne modifient pas cette distribution : seules les transmissions effectives sont retardées, comme le montrent `tests/test_poisson_independence.py`.
 
 Pour suivre les évolutions du projet, consultez le fichier `CHANGELOG.md`.
 

--- a/docs/equations_flora.md
+++ b/docs/equations_flora.md
@@ -10,7 +10,7 @@ Le module `flora_phy.py` reproduit la perte de parcours de FLoRa :
 loss = PATH_LOSS_D0 + 10 * n * math.log10(distance / REFERENCE_DISTANCE)
 ```
 
-avec `PATH_LOSS_D0 = 127.41` dB et `REFERENCE_DISTANCE = 40` m. L'exposant `n` vaut `2.7` pour le profil `flora`【F:README.md†L424-L433】【F:simulateur_lora_sfrd/launcher/flora_phy.py†L29-L61】.
+avec `PATH_LOSS_D0 = 127.41` dB et `REFERENCE_DISTANCE = 40` m. L'exposant `n` vaut `2.7` pour le profil `flora`【F:README.md†L424-L433】【F:loraflexsim/launcher/flora_phy.py†L29-L61】.
 
 ## Taux d'erreur paquet (PER)
 
@@ -23,7 +23,7 @@ permettant de basculer entre deux approximations :
   PER = 1 / (1 + math.exp(2 * (snr - (th + 2))))
   ```
 
-  où `th` est le seuil SNR du spreading factor courant【F:simulateur_lora_sfrd/launcher/flora_phy.py†L149-L152】.
+  où `th` est le seuil SNR du spreading factor courant【F:loraflexsim/launcher/flora_phy.py†L149-L152】.
 
 - ``"croce"`` — modèle analytique issu des expressions BER/SER :
 
@@ -39,7 +39,7 @@ permettant de basculer entre deux approximations :
   ```
 
   Cette formule suit l'approximation de Croce *et al.* pour un paquet de
-  ``payload_bytes`` octets【F:simulateur_lora_sfrd/launcher/flora_phy.py†L154-L161】.
+  ``payload_bytes`` octets【F:loraflexsim/launcher/flora_phy.py†L154-L161】.
 
 ## Calcul de l'airtime
 
@@ -68,7 +68,7 @@ t_preamble = (preamble_symbols + 4.25) * ts
 t_payload = n_payload * ts
 return t_preamble + t_payload
 ```
-【F:README.md†L642-L661】【F:simulateur_lora_sfrd/launcher/channel.py†L558-L570】
+【F:README.md†L642-L661】【F:loraflexsim/launcher/channel.py†L558-L570】
 
 ## Modèle OMNeT++
 
@@ -84,7 +84,7 @@ ser = 1 - (1 - ber) ** sf
 
 Cette expression donne directement la BER en fonction du rapport
 signal/bruit linéaire ``snir`` et du spreading factor ``sf``
-【F:simulateur_lora_sfrd/launcher/omnet_modulation.py†L7-L25】.
+【F:loraflexsim/launcher/omnet_modulation.py†L7-L25】.
 
 ## Seuil de détection (sensibilité)
 
@@ -99,4 +99,4 @@ threshold = Channel.FLORA_SENSITIVITY[sf][int(bandwidth)]
 Une méthode utilitaire expose ce calcul via
 ``Channel.flora_detection_threshold`` qui fournit ``-110`` dBm par défaut
 lorsque la paire ``(SF, BW)`` n'est pas présente dans la table
-【F:simulateur_lora_sfrd/launcher/channel.py†L52-L63】.
+【F:loraflexsim/launcher/channel.py†L52-L63】.

--- a/docs/extension_guide.md
+++ b/docs/extension_guide.md
@@ -23,7 +23,7 @@ Vous pouvez remplacer les classes du simulateur pour tester d'autres
 comportements :
 
 ```python
-from simulateur_lora_sfrd.launcher import Simulator, PathMobility
+from loraflexsim.launcher import Simulator, PathMobility
 
 class MyMobility(PathMobility):
     def step(self, node, dt):

--- a/docs/obstacle_loss.md
+++ b/docs/obstacle_loss.md
@@ -7,7 +7,7 @@ des bâtiments ou obstacles présents entre deux nœuds. Une carte d'obstacles p
 ## Chargement depuis un GeoJSON
 
 ```python
-from simulateur_lora_sfrd.launcher import Channel, ObstacleLoss
+from loraflexsim.launcher import Channel, ObstacleLoss
 
 loss = ObstacleLoss.from_geojson("examples/urban_buildings.geojson")
 ch = Channel(obstacle_loss=loss)


### PR DESCRIPTION
## Summary
- update docs and README to use new LoRaFlexSim package name
- refresh import paths and CLI examples

## Testing
- `pytest tests/test_adr.py tests/test_interval_distribution.py tests/test_poisson_independence.py`

------
https://chatgpt.com/codex/tasks/task_e_68ace67acfe083318f19463f3184080a