### PR TITLE
docs: mention LoRaFlexSim in extension guide

### DIFF
--- a/docs/extension_guide.md
+++ b/docs/extension_guide.md
@@ -1,7 +1,7 @@
-# Guide d'extension du tableau de bord
+# Guide d'extension du tableau de bord de LoRaFlexSim
 
-Ce document explique comment personnaliser `launcher/dashboard.py` et ajouter de
-nouvelles fonctionnalités au simulateur.
+Ce document explique comment personnaliser `launcher/dashboard.py` du tableau de
+bord de LoRaFlexSim et ajouter de nouvelles fonctionnalités au simulateur.
 
 ## Principe général
 


### PR DESCRIPTION
## Summary
- reference LoRaFlexSim in the extension guide dashboard introduction

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aceda65f1083319e982aa94fa282e2