### PR TITLE
chore: update dashboard import path

### DIFF
--- a/loraflexsim/launcher/tests/test_dashboard_validation.py
+++ b/loraflexsim/launcher/tests/test_dashboard_validation.py
@@ -1,7 +1,7 @@
 import pytest
 
 panel = pytest.importorskip("panel")
-dashboard = pytest.importorskip("simulateur_lora_sfrd.launcher.dashboard")
+dashboard = pytest.importorskip("loraflexsim.launcher.dashboard")
 
 
 def reset_inputs():

--- a/tests/test_dashboard_pause.py
+++ b/tests/test_dashboard_pause.py
@@ -3,7 +3,7 @@ import pytest
 import pytest
 
 try:
-    dashboard = pytest.importorskip('simulateur_lora_sfrd.launcher.dashboard')
+    dashboard = pytest.importorskip('loraflexsim.launcher.dashboard')
 except Exception:
     pytest.skip('dashboard import failed', allow_module_level=True)
 


### PR DESCRIPTION
## Summary
- update dashboard imports to use loraflexsim package

## Testing
- `pytest loraflexsim/launcher/tests/test_dashboard_validation.py tests/test_dashboard_pause.py` *(fails: AttributeError: module 'numpy_stub' has no attribute 'dtype')*

------
https://chatgpt.com/codex/tasks/task_e_68acededba388331b3bc3b9d0c367b81