### PR TITLE
Fix dashboard import references in tests

### DIFF
--- a/loraflexsim/launcher/tests/test_dashboard_validation.py
+++ b/loraflexsim/launcher/tests/test_dashboard_validation.py
@@ -1,7 +1,7 @@
 import pytest
 
 panel = pytest.importorskip("panel")
-dashboard = pytest.importorskip("simulateur_lora_sfrd.launcher.dashboard")
+dashboard = pytest.importorskip("loraflexsim.launcher.dashboard")
 
 
 def reset_inputs():

--- a/tests/test_dashboard_pause.py
+++ b/tests/test_dashboard_pause.py
@@ -1,9 +1,7 @@
 import pytest
 
-import pytest
-
 try:
-    dashboard = pytest.importorskip('simulateur_lora_sfrd.launcher.dashboard')
+    dashboard = pytest.importorskip('loraflexsim.launcher.dashboard')
 except Exception:
     pytest.skip('dashboard import failed', allow_module_level=True)
 


### PR DESCRIPTION
## Summary
- update dashboard import in dashboard pause test
- adjust dashboard import in launcher dashboard validation test

## Testing
- `pytest tests/test_dashboard_pause.py`
- `pytest loraflexsim/launcher/tests/test_dashboard_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_68acedf760a08331934193b73999d226